### PR TITLE
perhaps controversial: some qemu startup fixes

### DIFF
--- a/make.conf
+++ b/make.conf
@@ -67,6 +67,9 @@ OVMF_DIR ?= $(shell for d in $(OVMF_SEARCH); do [ -d "$$d" ] && break; done; ech
 OVMF_CODE = $(OVMF_DIR)/OVMF_CODE.secboot.fd
 OVMF_VARS = $(OVMF_DIR)/OVMF_VARS.fd
 
+NOGUI = -nodefaults \
+	-device VGA -vnc :9000 -serial mon:stdio
+
 QEMU_CMD_CORE = \
 	qemu-system-x86_64 \
 	  -machine type=q35,smm=on,accel=kvm -cpu host -smp 2 -m 1024 \
@@ -82,8 +85,12 @@ QEMU_CMD_CORE = \
 	  \
 	  -virtfs local,path=fs_virtfs,mount_tag=virtfs0,security_model=none \
 	  \
-	  -drive file=fat:rw:fs_esp,format=raw,media=disk \
+	  -drive file=fat:ro:fs_esp,format=raw,media=disk,if=none,id=fatdisk,readonly=on \
+	  -device driver=virtio-blk,drive=fatdisk \
 	  \
-	  -device virtio-net,netdev=nic -netdev user,id=nic
+	  -object "rng-random,filename=/dev/urandom,id=rng0" \
+	  -device "virtio-rng-pci,rng=rng0" \
+	  -nodefaults \
+	  $(NOGUI)
 
 # kate: syntax Makefile;


### PR DESCRIPTION
1. add rng device
2. use readonly virtfs mount
3. use nographics
4. do not use virtio-net

Signed-off-by: Serge Hallyn <serge@hallyn.com>