### PR TITLE
BUG: remove Paul Moore as the main contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 QEMU UEFI Secure Boot Development Environment
 ===============================================================================
-Contact: pmoore2@cisco.com or paul@paul-moore.com
 
 This repository provides a UEFI Secure Boot development environment based on
 QEMU, OVMF, and the libtpms/swtpm TPM emulator.  Links to all of these


### PR DESCRIPTION
As my Cisco email is no longer valid and I'm not actively working
with this project, it seems wrong to keep my name as the main point
of contact.

Signed-off-by: Paul Moore <paul@paul-moore.com>