### PR TITLE
support swtpm on ubuntu

### DIFF
--- a/tools/run-sw-tpm
+++ b/tools/run-sw-tpm
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-[ -d .tpm2 ] || mkdir .tpm2
+mktpm2() {
+	d=$(mktemp -d)
+	ln -s $d .tpm2
+}
+
+[ -d .tpm2 ] || mktpm2
 if [ -f .tpm2/pid ]; then
     kill -9 $(<.tpm2/pid) || true
     rm .tpm2/pid


### PR DESCRIPTION
The apparmor profile for swtpm in ubuntu rejects usage of sockfile under $HOME.  So mktemp in /tmp and link that to .tpm2/.

Signed-off-by: Serge Hallyn <serge@hallyn.com>